### PR TITLE
Change useless 'option' argument into 'root_key' argument

### DIFF
--- a/lib/ruson/base.rb
+++ b/lib/ruson/base.rb
@@ -20,9 +20,9 @@ module Ruson
       end
     end
 
-    def initialize(json, options = {})
+    def initialize(json, root_key: nil)
       params  = convert(json)
-      params  = params[options[:root].to_s] unless options[:root].nil?
+      params  = params[root_key.to_s] unless root_key.nil?
       @params = params
 
       self.class.accessors.each do |key, options|

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Ruson::Base do
     field :objects, each_class: RusonBaseTestSubClass2
   end
 
-  let(:text){ '{"object": { "test_name": "object_name" }, "objects": [ { "source_key_name": "1" }, { "source_key_name": "2" }, { "source_key_name": "3" } ] }' }
+  let(:text) { '{"object": { "test_name": "object_name" }, "objects": [ { "source_key_name": "1" }, { "source_key_name": "2" }, { "source_key_name": "3" } ] }' }
 
   it do
     obj = RusonBaseTestSubClass.new({})
@@ -28,6 +28,11 @@ RSpec.describe Ruson::Base do
   end
 
   it do
+    obj = RusonBaseTestSubClass.new({ root: { test_name: 'test' } }, root_key: :root)
+    expect(obj.test_name).to eq 'test'
+  end
+
+  it do
     obj           = RusonBaseTestSubClass.new({ test_name: 'test' })
     obj.test_name = 'testtest'
     expect(obj.test_name).to eq 'testtest'
@@ -35,6 +40,11 @@ RSpec.describe Ruson::Base do
 
   it do
     obj = RusonBaseTestSubClass.new({ test_name: 'test' }.to_json)
+    expect(obj.test_name).to eq 'test'
+  end
+
+  it do
+    obj = RusonBaseTestSubClass.new({ root: { test_name: 'test' } }.to_json, root_key: :root)
     expect(obj.test_name).to eq 'test'
   end
 


### PR DESCRIPTION
`initialize` needs only `root_key` argument.