### PR TITLE
Fixes Rspec deprecation warnings

### DIFF
--- a/spec/nilable_spec.rb
+++ b/spec/nilable_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe Ruson::Nilable do
   it 'is not raised NotNilException' do
     expect {
       Item.new({ id: 2 })
-    }.not_to raise_error(Ruson::NotNilException)
+    }.not_to raise_error
     expect {
       Item.new({ id: 2, name: 'name' })
-    }.not_to raise_error(Ruson::NotNilException)
+    }.not_to raise_error
     expect {
       Item.new({ id: 2, name: 'name', description: 'description' })
-    }.not_to raise_error(Ruson::NotNilException)
+    }.not_to raise_error
     expect {
       Item.new('{"id":2,"name":"name","description":"description"}')
-    }.not_to raise_error(Ruson::NotNilException)
+    }.not_to raise_error
   end
 
   it 'is raised NotNilException' do


### PR DESCRIPTION
Rspec was showing the following deprecation warnings:

```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /gem/spec/nilable_spec.rb:11:in `block (2 levels) in <top (required)>'.
```