### PR TITLE
Implements model persistence (Relates #22)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# How to use it
+# =============
+#
+# Visit https://blog.zedroot.org/2015/04/30/using-docker-to-maintain-a-ruby-gem/
+
+# ~~~~ Image base ~~~~
+# Base image
+FROM ruby:2.6.5-alpine
+LABEL maintainer="klriutsa"
+
+RUN mkdir -p /gem/
+WORKDIR /gem/
+ADD . /gem/
+
+# ~~~~ OS Maintenance & Rails Preparation ~~~~
+# Rubygems and Bundler
+RUN apk add --no-cache \
+            --quiet \
+            build-base \
+            git \
+  && touch ~/.gemrc \
+  && echo "gem: --no-ri --no-rdoc" >> ~/.gemrc \
+  && gem install rubygems-update \
+  && update_rubygems \
+  && gem install bundler \
+  && bundle install \
+  && rm -rf /var/cache/apk/*
+
+ENTRYPOINT ["bundle", "exec"]
+CMD ["rake", "-T"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Or install it yourself as:
 
 ## Usage
 
+### Basic
+
 post.json
 ```json
 {
@@ -42,7 +44,7 @@ post.title #=> 'Ruson'
 post.content #=> 'Welcome!'
 ```
 
-### name
+#### name
 
 post.json
 ```json
@@ -65,7 +67,7 @@ post = Post.new(json)
 post.url #=> 'http://sample.com'
 ```
 
-### nilable
+#### nilable
 
 post.json
 ```json
@@ -85,9 +87,9 @@ json = File.read('post.json')
 post = Post.new(json) #=> Ruson::NotNilException
 ```
 
-### nested class
+#### nested class
 
-#### class
+##### class
 
 post.json
 ```json
@@ -119,7 +121,7 @@ post = Post.new(json)
 post.picture.url #=> 'http://sample.com/picture.png'
 ```
 
-##### Primary classes
+###### Primary classes
 
 * Boolean
 * Integer
@@ -151,7 +153,7 @@ post.view #=> 1234
 post.rate #=> 3.8
 ```
 
-#### each class
+##### each class
 
 post.json
 ```json
@@ -185,7 +187,7 @@ post = Post.new(json)
 post.tags.first.name #=> 'Ruby'
 ```
 
-### enum
+#### enum
 
 article.json
 ```json
@@ -213,7 +215,7 @@ article.status = 'undefined'
   #=> undefined is not a valid status (ArgumentError)
 ```
 
-### to_json
+#### to_json
 
 ```ruby
 class Post < Ruson::Base
@@ -228,7 +230,7 @@ post.url = 'https://example.com/examples'
 post.to_json #=> "{\"title\":\"Ruson\",\"url\":\"https://example.com/examples\"}"
 ```
 
-### to_hash
+#### to_hash
 
 ```ruby
 class Post < Ruson::Base
@@ -243,7 +245,7 @@ post.url = 'https://example.com/examples'
 post.to_hash #=> {title: "Ruson", url: "https://example.com/examples" }
 ```
 
-### API json parser
+#### API json parser
 
 ```ruby
 class Article < Ruson::Base
@@ -261,11 +263,110 @@ article = Article.new(response.body)
 article.title
 ```
 
+### Persistence
+
+Persistence will save the models as JSON file, with the model ID as filename, and model class name as parent folder so that a `User` model with ID `1` will be saved as `Users/1.json`.
+
+You *must* define the `output_folder` before to be able to call `save` or `destroy`.
+
+```ruby
+Ruson.output_folder = './db/'
+```
+
+#### Creating new record
+
+```ruby
+class User < Ruson::Base
+  field :first_name
+  field :last_name
+  field :email
+  field :title
+end
+
+# Using new + save
+guillaume = User.new(first_name: 'Guillaume', last_name: 'Briat', email: 'guillaume@kaamelott.fr')
+guillaume.save # Creates the ./db/Users/1.json file
+
+# Or using the create method
+guillaume = User.create(first_name: 'Guillaume', last_name: 'Briat', email: 'guillaume@kaamelott.fr')
+
+puts File.read('./db/Users/1.json')
+{"first_name":"Guillaume","last_name":"Briat","email":"guillaume@kaamelott.fr"}
+=> nil
+```
+
+#### Updating a record
+
+```ruby
+# Assigning a value + save
+guillaume.title = 'Burgundians King'
+guillaume.save # Updates the ./db/Users/1.json file
+
+# Or using the update method
+guillaume.update(title: 'Burgundians King')
+
+puts File.read('./db/Users/1.json')
+{"first_name":"Guillaume","last_name":"Briat","email":"guillaume@kaamelott.fr","title":"Burgundians King"}
+=> nil
+```
+
+#### Destroying a record
+
+```ruby
+guillaume.destroy # Deletes the ./db/Users/1.json file
+
+puts File.read('./db/Users/1.json')
+Traceback (most recent call last):
+       16: from /usr/local/bundle/gems/bundler-2.0.2/exe/bundle:30:in `block in <top (required)>'
+       ...
+        2: from (irb):26
+        1: from (irb):26:in `read'
+Errno::ENOENT (No such file or directory @ rb_sysopen - ./db/Users/1.json)
+```
+
 ## Development
+
+### Without Docker
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+### With Docker
+
+```
+$ docker build -t `whoami`/ruson .
+```
+
+In order to see the available Rake tasks:
+
+```
+$ docker --rm `whoami`/ruson
+rake build            # Build ruson-1.2.0.gem into the pkg directory
+rake clean            # Remove any temporary products
+rake clobber          # Remove any generated files
+rake install          # Build and install ruson-1.2.0.gem into system gems
+rake install:local    # Build and install ruson-1.2.0.gem into system gems without network access
+rake release[remote]  # Create tag v1.2.0 and build and push ruson-1.2.0.gem to rubygems.org
+rake spec             # Run RSpec code examples
+```
+_`--rm` means delete the container after the command ended._
+
+In order to execute the tests:
+
+```
+$ docker run --rm -it --volume "$PWD":/gem/ `whoami`/ruson rake spec
+```
+_`--volume` is used to sync the files from your current folder into the container so that if you change a file, the modification is available in the container._
+
+In the case you'd like to access the IRB console:
+
+```
+$ docker run --rm -it --volume "$PWD":/gem/ `whoami`/ruson irb
+irb(main):001:0> require 'ruson'
+=> true
+irb(main):002:0>
+```
 
 ## Contributing
 

--- a/lib/ruson.rb
+++ b/lib/ruson.rb
@@ -2,5 +2,6 @@ require 'ruson/base'
 require 'ruson/version'
 
 module Ruson
-
+  # Output folder where Ruson will save models data
+  mattr_accessor :output_folder
 end

--- a/lib/ruson/base.rb
+++ b/lib/ruson/base.rb
@@ -3,8 +3,9 @@ require 'active_support'
 require 'active_support/core_ext'
 
 require 'ruson/class/boolean'
-require 'ruson/class/integer'
 require 'ruson/class/float'
+require 'ruson/class/integer'
+require 'ruson/class/time'
 
 require 'ruson/converter'
 require 'ruson/json'
@@ -66,7 +67,17 @@ module Ruson
     end
 
     def to_hash
-      convert_to_hash(self.class.accessors)
+      res = convert_to_hash(self.class.accessors)
+
+      res.inject({}) do |result, attributes|
+        key, value = attributes
+        if self.class.accessors[key].key?(:name)
+          result[self.class.accessors[key][:name].to_s] = value
+        else
+          result[key] = value
+        end
+        result
+      end
     end
 
     def to_json
@@ -77,8 +88,7 @@ module Ruson
 
     def init_attributes(accessors, params)
       accessors.each do |key, options|
-        key_name = options[:name] || key
-        value = params[key_name]
+        value = params[options[:name]] || params[key]
 
         check_nilable(value, options)
         val = get_val(value, options)

--- a/lib/ruson/base.rb
+++ b/lib/ruson/base.rb
@@ -8,8 +8,9 @@ require 'ruson/class/float'
 
 require 'ruson/converter'
 require 'ruson/json'
-require 'ruson/value'
 require 'ruson/nilable'
+require 'ruson/persistence'
+require 'ruson/value'
 
 require 'ruson/error'
 
@@ -55,8 +56,9 @@ module Ruson
 
     include Ruson::Converter
     include Ruson::Json
-    include Ruson::Value
     include Ruson::Nilable
+    include Ruson::Persistence
+    include Ruson::Value
 
     def initialize(json, root_key: nil)
       params = get_hash_from_json(json)
@@ -84,6 +86,9 @@ module Ruson
         val = get_val(value, options)
         set_attribute(key, val)
       end
+
+      self.class.attr_accessor(:id)
+      set_attribute(:id, params[:id]) if params[:id]
     end
 
     def set_attribute(attr_name, val)

--- a/lib/ruson/class/time.rb
+++ b/lib/ruson/class/time.rb
@@ -1,0 +1,5 @@
+class Time
+  def self.new(value)
+    Time.at(value).to_datetime
+  end
+end

--- a/lib/ruson/class/time.rb
+++ b/lib/ruson/class/time.rb
@@ -1,5 +1,12 @@
 class Time
   def self.new(value)
-    Time.at(value).to_datetime
+    case value
+    when Integer, Float
+      Time.at(value).to_time
+    when String
+      Time.parse(value).to_time
+    else
+      value
+    end
   end
 end

--- a/lib/ruson/persistence.rb
+++ b/lib/ruson/persistence.rb
@@ -72,7 +72,16 @@ module Ruson
     end
 
     def update(attributes)
-      attributes.each { |key, value| send("#{key}=", value) }
+      attributes.symbolize_keys!
+
+      # Takes only accessor for attributes to be updated, avoiding to nullify
+      # the other attributes.
+      filtered_accessors = self.class.accessors.select do |key, accessor_attrs|
+        attributes.key?(key) || attributes.key?(accessor_attrs[:name])
+      end
+
+      update_attributes(filtered_accessors, attributes)
+
       save
     end
   end

--- a/lib/ruson/persistence.rb
+++ b/lib/ruson/persistence.rb
@@ -1,0 +1,80 @@
+module Ruson
+  module Persistence
+    def self.included(klass)
+      klass.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def create(*args)
+        new_record = new(*args)
+        new_record.save
+        new_record
+      end
+
+      def model_base_path
+        File.join(Ruson.output_folder, "#{self.name}s")
+      end
+    end
+
+    def delete_file_from_disk
+      FileUtils.rm_f(model_path)
+    end
+
+    def destroy
+      delete_file_from_disk
+      true
+    end
+
+    def ensure_output_folder_is_defined
+      return if Ruson.output_folder
+
+      raise ArgumentError, 'No output folder defined. You can define it ' \
+                           'using Ruson.output_folder = "/path/to/db/folder"'
+    end
+
+    def ensure_model_folder_exists
+      return if File.exist?(self.class.model_base_path)
+
+      FileUtils.mkdir_p(self.class.model_base_path)
+    end
+
+    def generate_uniq_id
+      ensure_model_folder_exists
+
+      return if id
+
+      id = 0
+
+      Dir.glob(File.join(self.class.model_base_path, '*.json')).each do |file|
+        file_id = File.basename(file, '.json').to_i
+
+        id = file_id if file_id > id
+      end
+
+      self.id = id + 1
+    end
+
+    def model_path
+      File.join(self.class.model_base_path, "#{id}.json")
+    end
+
+    def write_file_to_disk
+      File.open(model_path, 'w') do |file|
+        file.write(to_json)
+      end
+    end
+
+    def save
+      ensure_output_folder_is_defined
+      generate_uniq_id
+      write_file_to_disk
+      true
+    end
+
+    def update(attributes)
+      attributes.each { |key, value| send("#{key}=", value) }
+      save
+    end
+  end
+end
+

--- a/ruson.gemspec
+++ b/ruson.gemspec
@@ -21,8 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_dependency 'activesupport'
+
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'timecop', '~> 0.9.1'
 end

--- a/spec/class/time_spec.rb
+++ b/spec/class/time_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe Time do
+  class TimeObject < Ruson::Base
+    field :created_at, class: Time
+  end
+
+  before do
+    @now = Time.local(2019, 11, 30, 10, 17, 0)
+    Timecop.freeze(@now)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  it 'cast Time to Time' do
+    obj = TimeObject.new(created_at: @now)
+    expect(obj.created_at).to eq @now
+  end
+
+  it 'cast Interger to Time' do
+    obj = TimeObject.new(created_at: @now.to_i)
+    expect(obj.created_at).to eq @now
+  end
+
+  it 'cast Float to time' do
+    obj = TimeObject.new(created_at: @now.to_f)
+    expect(obj.created_at).to eq @now
+  end
+
+  it 'cast String to time' do
+    obj = TimeObject.new(created_at: @now.to_s)
+    expect(obj.created_at).to eq @now
+  end
+end

--- a/spec/field_name_spec.rb
+++ b/spec/field_name_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'field name attribute' do
+  context 'importing model data for a model with a named field' do
+    it 'should import the named attribute from the JSON' do
+      vehicle = Vehicle.new(
+        name: 'Black Sims',
+        price: 17.43,
+        'expiredAt' => 1575608400.0
+      )
+
+      expect(vehicle.expired_at).to eq(Time.at(1575608400.0).to_datetime)
+    end
+  end
+
+  context 'exporting model with a named field' do
+    it 'should name the JSON attribute as the field name' do
+      vehicle = Vehicle.new(
+        name: 'Black Sims',
+        price: 17.43,
+        expired_at: 1575608400.0
+      )
+
+      expect(vehicle.to_hash).to eq(
+        name: 'Black Sims',
+        price: 17.43,
+        'expiredAt' => Time.at(1575608400.0).to_datetime
+      )
+    end
+  end
+end

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -145,25 +145,21 @@ RSpec.describe 'Persistence' do
       end
 
       context 'using the update method' do
-        subject do
-          user = User.new(name: 'zedtux')
-          user.save
-          user
-        end
+        subject { Vehicle.create(name: 'Jean Bart') }
 
         it 'should update all the given attributes' do
-          expect(
-            subject.update(url: 'https://github.com/klriutsa/ruson')
-          ).to be_truthy
+          now = Time.now
+          expect(subject.update(expiredAt: now, price: 12)).to be_truthy
 
           saved_data = File.read(
-            File.join(Ruson.output_folder, 'Users', "#{subject.id}.json")
+            File.join(Ruson.output_folder, 'Vehicles', "#{subject.id}.json")
           )
           expect(saved_data).to eq(
-            User.new(
+            Vehicle.new(
               id: 1,
-              name: 'zedtux',
-              url: 'https://github.com/klriutsa/ruson'
+              name: 'Jean Bart',
+              price: 12,
+              expired_at: now
             ).to_json
           )
         end

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -1,0 +1,189 @@
+require 'spec_helper'
+
+RSpec.describe 'Persistence' do
+  RUSON_DB_PATH = './db/'.freeze
+
+  after(:all) { FileUtils.rm_rf(RUSON_DB_PATH) }
+
+  context 'without an output folder' do
+    it 'should raise an ArgumentError' do
+      expect {
+        User.new({}).save
+      }.to raise_error(
+        ArgumentError,
+        'No output folder defined. You can define it using ' \
+        'Ruson.output_folder = "/path/to/db/folder"'
+      )
+    end
+  end
+
+  context 'with an output folder' do
+    before do
+      Ruson.output_folder = RUSON_DB_PATH
+      FileUtils.rm_rf(Ruson.output_folder)
+    end
+
+    describe 'Unique ID generation' do
+      it 'should generate a uniq ID' do
+        user = User.new({})
+        user.save
+        expect(user.id).to be_present
+      end
+
+      context 'without any existing files for the current model' do
+        it 'should assign the ID 1' do
+          user = User.new({})
+          user.save
+
+          expect(user.id).to eq 1
+        end
+      end
+
+      context 'with an existing JSON file for the current model, but with an ' \
+              'invalid name' do
+        before do
+          # Generate an invalid file
+          FileUtils.mkdir_p('./db/Users')
+          File.open('./db/Users/test.json', 'w') { |file| file.write('{}') }
+        end
+        it 'should assign the ID 1' do
+          user = User.new({})
+          user.save
+
+          expect(user.id).to eq 1
+        end
+      end
+
+      context 'with an existing JSON file for the current model' do
+        before { User.new({}).save }
+        it 'should assign the ID 2' do
+          user = User.new({})
+          user.save
+
+          expect(user.id).to eq 2
+        end
+      end
+
+      context 'with an existing JSON file for the current model but its ' \
+              'filename is ID 10' do
+        before do
+          FileUtils.mkdir_p('./db/Users')
+          File.open('./db/Users/10.json', 'w') do |file|
+            file.write(User.new({}.to_json))
+          end
+        end
+
+        it 'should assign the ID 11' do
+          user = User.new({})
+          user.save
+
+          expect(user.id).to eq 11
+        end
+      end
+    end
+
+    describe 'Model creation' do
+      def model_path(user_id)
+        File.join(Ruson.output_folder, 'Users', "#{user_id}.json")
+      end
+
+      context 'using new and save' do
+        it 'should create a file with the id as filename' do
+          user = User.new({})
+          user.save
+
+          expect(File).to exist(model_path(user.id))
+        end
+
+        it 'should have save all the attributes to the file' do
+          user = User.new({})
+          user.save
+
+          expect(File.read(model_path(user.id))).to eq(user.to_json)
+        end
+      end
+
+      context 'using create' do
+        it 'should create a file with the id as filename' do
+          user = User.create({})
+
+          expect(File).to exist(model_path(user.id))
+        end
+
+        it 'should have save all the attributes to the file' do
+          user = User.create({})
+
+          expect(File.read(model_path(user.id))).to eq(user.to_json)
+        end
+      end
+    end
+
+    describe 'Model update' do
+      context 'updating an attribute and calling save' do
+        subject do
+          user = User.new(name: 'zedtux')
+          user.save
+          user
+        end
+
+        it 'should update the model file' do
+          subject.url = 'https://github.com/klriutsa/ruson'
+
+          expect(subject.save).to be_truthy
+
+          saved_data = File.read(
+            File.join(Ruson.output_folder, 'Users', "#{subject.id}.json")
+          )
+          expect(saved_data).to eq(
+            User.new(
+              id: 1,
+              name: 'zedtux',
+              url: 'https://github.com/klriutsa/ruson'
+            ).to_json
+          )
+        end
+      end
+
+      context 'using the update method' do
+        subject do
+          user = User.new(name: 'zedtux')
+          user.save
+          user
+        end
+
+        it 'should update all the given attributes' do
+          expect(
+            subject.update(url: 'https://github.com/klriutsa/ruson')
+          ).to be_truthy
+
+          saved_data = File.read(
+            File.join(Ruson.output_folder, 'Users', "#{subject.id}.json")
+          )
+          expect(saved_data).to eq(
+            User.new(
+              id: 1,
+              name: 'zedtux',
+              url: 'https://github.com/klriutsa/ruson'
+            ).to_json
+          )
+        end
+      end
+    end
+
+    describe 'Model destroy' do
+      subject do
+        user = User.new(name: 'zedtux')
+        user.save
+        user
+      end
+
+      it 'should delete the file' do
+        subject.destroy
+
+        expect(File).to_not exist(
+          File.join(Ruson.output_folder, 'Users', "#{subject.id}.json")
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'ruson'
 require 'support/objects'
+require 'timecop'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/objects.rb
+++ b/spec/support/objects.rb
@@ -24,3 +24,9 @@ class Post < Ruson::Base
   field :tags, each_class: Tag
   enum :status, %i[draft published]
 end
+
+class Vehicle < Ruson::Base
+  field :name
+  field :price
+  field :expired_at, name: 'expiredAt', class: Time
+end


### PR DESCRIPTION
**WARNING:** The PR #28 should be merged before this one. This PR needed the content of #28 in order to work so the branch has been merged in this one... sorry.

This commits adds the `save`, `update` and `destroy` methods to models.
* `save` creates or updates a JSON file of the model into a parent folder having the model's class name
* `update` updates the model attributes then call `save`
* `destroy` deletes the model's JSON file