### PR TITLE
Bug/fixes named field on exporting

### DIFF
--- a/lib/ruson/base.rb
+++ b/lib/ruson/base.rb
@@ -3,8 +3,9 @@ require 'active_support'
 require 'active_support/core_ext'
 
 require 'ruson/class/boolean'
-require 'ruson/class/integer'
 require 'ruson/class/float'
+require 'ruson/class/integer'
+require 'ruson/class/time'
 
 require 'ruson/converter'
 require 'ruson/json'
@@ -66,7 +67,17 @@ module Ruson
     end
 
     def to_hash
-      convert_to_hash(self.class.accessors)
+      res = convert_to_hash(self.class.accessors)
+
+      res.inject({}) do |result, attributes|
+        key, value = attributes
+        if self.class.accessors[key].key?(:name)
+          result[self.class.accessors[key][:name].to_s] = value
+        else
+          result[key] = value
+        end
+        result
+      end
     end
 
     def to_json
@@ -77,8 +88,7 @@ module Ruson
 
     def init_attributes(accessors, params)
       accessors.each do |key, options|
-        key_name = options[:name] || key
-        value = params[key_name]
+        value = params[options[:name]] || params[key]
 
         check_nilable(value, options)
         val = get_val(value, options)

--- a/lib/ruson/class/time.rb
+++ b/lib/ruson/class/time.rb
@@ -1,0 +1,5 @@
+class Time
+  def self.new(value)
+    Time.at(value).to_datetime
+  end
+end

--- a/lib/ruson/class/time.rb
+++ b/lib/ruson/class/time.rb
@@ -1,5 +1,12 @@
 class Time
   def self.new(value)
-    Time.at(value).to_datetime
+    case value
+    when Integer, Float
+      Time.at(value).to_time
+    when String
+      Time.parse(value).to_time
+    else
+      value
+    end
   end
 end

--- a/ruson.gemspec
+++ b/ruson.gemspec
@@ -21,8 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_dependency 'activesupport'
+
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'timecop', '~> 0.9.1'
 end

--- a/spec/class/time_spec.rb
+++ b/spec/class/time_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe Time do
+  class TimeObject < Ruson::Base
+    field :created_at, class: Time
+  end
+
+  before do
+    @now = Time.local(2019, 11, 30, 10, 17, 0)
+    Timecop.freeze(@now)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  it 'cast Time to Time' do
+    obj = TimeObject.new(created_at: @now)
+    expect(obj.created_at).to eq @now
+  end
+
+  it 'cast Interger to Time' do
+    obj = TimeObject.new(created_at: @now.to_i)
+    expect(obj.created_at).to eq @now
+  end
+
+  it 'cast Float to time' do
+    obj = TimeObject.new(created_at: @now.to_f)
+    expect(obj.created_at).to eq @now
+  end
+
+  it 'cast String to time' do
+    obj = TimeObject.new(created_at: @now.to_s)
+    expect(obj.created_at).to eq @now
+  end
+end

--- a/spec/field_name_spec.rb
+++ b/spec/field_name_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'field name attribute' do
+  context 'importing model data for a model with a named field' do
+    it 'should import the named attribute from the JSON' do
+      vehicle = Vehicle.new(
+        name: 'Black Sims',
+        price: 17.43,
+        'expiredAt' => 1575608400.0
+      )
+
+      expect(vehicle.expired_at).to eq(Time.at(1575608400.0).to_datetime)
+    end
+  end
+
+  context 'exporting model with a named field' do
+    it 'should name the JSON attribute as the field name' do
+      vehicle = Vehicle.new(
+        name: 'Black Sims',
+        price: 17.43,
+        expired_at: 1575608400.0
+      )
+
+      expect(vehicle.to_hash).to eq(
+        name: 'Black Sims',
+        price: 17.43,
+        'expiredAt' => Time.at(1575608400.0).to_datetime
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'ruson'
 require 'support/objects'
+require 'timecop'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/objects.rb
+++ b/spec/support/objects.rb
@@ -24,3 +24,9 @@ class Post < Ruson::Base
   field :tags, each_class: Tag
   enum :status, %i[draft published]
 end
+
+class Vehicle < Ruson::Base
+  field :name
+  field :price
+  field :expired_at, name: 'expiredAt', class: Time
+end


### PR DESCRIPTION
This PR should be merged after #24 and #25.

This PR adds support for `Time` class fields (Closes #27) and also uses the named field when converting a model instance as a Hash.