### PR TITLE
Fixes calling `find` or `find!` without output folder

### DIFF
--- a/lib/ruson/base.rb
+++ b/lib/ruson/base.rb
@@ -58,6 +58,7 @@ module Ruson
       end
     end
 
+    # ~~~~ Mixins ~~~~
     include Ruson::Converter
     include Ruson::Json
     include Ruson::Nilable
@@ -65,6 +66,15 @@ module Ruson
     include Ruson::Querying
     include Ruson::Value
 
+    # ~~~~ Class Methods ~~~~
+    def self.ensure_output_folder_is_defined
+      return if Ruson.output_folder
+
+      raise ArgumentError, 'No output folder defined. You can define it ' \
+                           'using Ruson.output_folder = "/path/to/db/folder"'
+    end
+
+    # ~~~~ Instance Methods ~~~~
     def initialize(json, root_key: nil)
       params = get_hash_from_json(json)
       params = params[root_key.to_s] unless root_key.nil?

--- a/lib/ruson/persistence.rb
+++ b/lib/ruson/persistence.rb
@@ -25,13 +25,6 @@ module Ruson
       true
     end
 
-    def ensure_output_folder_is_defined
-      return if Ruson.output_folder
-
-      raise ArgumentError, 'No output folder defined. You can define it ' \
-                           'using Ruson.output_folder = "/path/to/db/folder"'
-    end
-
     def ensure_model_folder_exists
       return if File.exist?(self.class.model_base_path)
 
@@ -65,7 +58,7 @@ module Ruson
     end
 
     def save
-      ensure_output_folder_is_defined
+      self.class.ensure_output_folder_is_defined
       generate_uniq_id
       write_file_to_disk
       true

--- a/lib/ruson/querying.rb
+++ b/lib/ruson/querying.rb
@@ -6,6 +6,8 @@ module Ruson
 
     module ClassMethods
       def find(id)
+        ensure_output_folder_is_defined
+
         file_path = File.join(model_base_path, "#{id}.json")
 
         return unless File.exist?(file_path)

--- a/spec/querying_spec.rb
+++ b/spec/querying_spec.rb
@@ -12,63 +12,81 @@ RSpec.describe 'Querying' do
   after(:all) { FileUtils.rm_rf('./db/') }
 
   describe 'search by ID' do
-    describe 'using find' do
-      context "searching a record which doesn't exist" do
-        it 'should raise a Ruson::RecordNotFound error' do
-          expect {
-            user = Vehicle.find(999)
-            expect(user).to be_nil
-          }.to_not raise_error
-        end
-      end
+    context 'without an output folder' do
+      before { Ruson.output_folder = nil }
 
-      context 'searching existing records' do
-        it 'should not raise error' do
-          expect {
-            Vehicle.find(1)
-          }.to_not raise_error
-        end
-
-        it 'should return the Vehicle instance for the given ID' do
-          vehicle = Vehicle.find(1)
-
-          expected_vehicle = Vehicle.new(name: @user1_name).to_hash
-          expected_vehicle[:id] = 1 # Forces the ID
-
-          expect(vehicle.to_hash).to eq(expected_vehicle)
-
-          vehicle = Vehicle.find(2)
-
-          expected_vehicle = Vehicle.new(name: @user2_name).to_hash
-          expected_vehicle[:id] = 2 # Forces the ID
-
-          expect(vehicle.to_hash).to eq(expected_vehicle)
-        end
+      it 'should raise an ArgumentError' do
+        expect {
+          Vehicle.find(999)
+        }.to raise_error(
+          ArgumentError,
+          'No output folder defined. You can define it using ' \
+          'Ruson.output_folder = "/path/to/db/folder"'
+        )
       end
     end
 
-    describe 'using find!' do
-      context "searching a record which doesn't exist" do
-        it 'should raise a Ruson::RecordNotFound error' do
-          expect {
-            Vehicle.find!(999)
-          }.to raise_error(Ruson::RecordNotFound)
+    context 'with an output folder' do
+      before { Ruson.output_folder = './db/' }
+
+      describe 'using find' do
+        context "searching a record which doesn't exist" do
+          it 'should raise a Ruson::RecordNotFound error' do
+            expect {
+              user = Vehicle.find(999)
+              expect(user).to be_nil
+            }.to_not raise_error
+          end
+        end
+
+        context 'searching existing records' do
+          it 'should not raise error' do
+            expect {
+              Vehicle.find(1)
+            }.to_not raise_error
+          end
+
+          it 'should return the Vehicle instance for the given ID' do
+            vehicle = Vehicle.find(1)
+
+            expected_vehicle = Vehicle.new(name: @user1_name).to_hash
+            expected_vehicle[:id] = 1 # Forces the ID
+
+            expect(vehicle.to_hash).to eq(expected_vehicle)
+
+            vehicle = Vehicle.find(2)
+
+            expected_vehicle = Vehicle.new(name: @user2_name).to_hash
+            expected_vehicle[:id] = 2 # Forces the ID
+
+            expect(vehicle.to_hash).to eq(expected_vehicle)
+          end
         end
       end
 
-      context 'searching existing records' do
-        it 'should not raise error' do
-          expect {
-            Vehicle.find!(1)
-          }.to_not raise_error
+      describe 'using find!' do
+        context "searching a record which doesn't exist" do
+          it 'should raise a Ruson::RecordNotFound error' do
+            expect {
+              Vehicle.find!(999)
+            }.to raise_error(Ruson::RecordNotFound)
+          end
         end
 
-        it 'should return the Vehicle instance for the given ID' do
-          user = Vehicle.find!(1)
-          expect(user.to_hash).to eq(@user1.to_hash)
+        context 'searching existing records' do
+          it 'should not raise error' do
+            expect {
+              Vehicle.find!(1)
+            }.to_not raise_error
+          end
 
-          user = Vehicle.find!(2)
-          expect(user.to_hash).to eq(@user2.to_hash)
+          it 'should return the Vehicle instance for the given ID' do
+            user = Vehicle.find!(1)
+            expect(user.to_hash).to eq(@user1.to_hash)
+
+            user = Vehicle.find!(2)
+            expect(user.to_hash).to eq(@user2.to_hash)
+          end
         end
       end
     end


### PR DESCRIPTION
I discovered a bug so here is a PR in order to fix it.

Basically calling `find` or `find!` without defining the `Ruson.output_folder` was raising a nil to string convertion error. This PR solves that.