### PR TITLE
Removes the id from the JSON file

### DIFF
--- a/lib/ruson/base.rb
+++ b/lib/ruson/base.rb
@@ -96,8 +96,12 @@ module Ruson
       end
     end
 
-    def to_json
-      to_hash.to_json
+    def to_json(options = {})
+      hash = to_hash
+
+      options[:exclude]&.each { |key| hash.delete(key) }
+
+      hash.to_json
     end
 
     private

--- a/lib/ruson/persistence.rb
+++ b/lib/ruson/persistence.rb
@@ -53,7 +53,7 @@ module Ruson
 
     def write_file_to_disk
       File.open(model_path, 'w') do |file|
-        file.write(to_json)
+        file.write(to_json(exclude: %i[id]))
       end
     end
 

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -99,7 +99,9 @@ RSpec.describe 'Persistence' do
           user = User.new({})
           user.save
 
-          expect(File.read(model_path(user.id))).to eq(user.to_json)
+          expect(
+            File.read(model_path(user.id))
+          ).to eq(user.to_json(exclude: %i[id]))
         end
       end
 
@@ -113,7 +115,9 @@ RSpec.describe 'Persistence' do
         it 'should have save all the attributes to the file' do
           user = User.create({})
 
-          expect(File.read(model_path(user.id))).to eq(user.to_json)
+          expect(
+            File.read(model_path(user.id))
+          ).to eq(user.to_json(exclude: %i[id]))
         end
       end
     end
@@ -136,10 +140,9 @@ RSpec.describe 'Persistence' do
           )
           expect(saved_data).to eq(
             User.new(
-              id: 1,
               name: 'zedtux',
               url: 'https://github.com/klriutsa/ruson'
-            ).to_json
+            ).to_json(exclude: %i[id])
           )
         end
       end
@@ -156,11 +159,10 @@ RSpec.describe 'Persistence' do
           )
           expect(saved_data).to eq(
             Vehicle.new(
-              id: 1,
               name: 'Jean Bart',
               price: 12,
               expired_at: now
-            ).to_json
+            ).to_json(exclude: %i[id])
           )
         end
       end


### PR DESCRIPTION
The id field wasn't filtered from the JSON file written to the disk until this commit. As the ID is already the filename, having it in the JSON file doesn't sense